### PR TITLE
fix: Add regression test to prevent path escape via prefix substring matching

### DIFF
--- a/features/reference/allow-paths.feature
+++ b/features/reference/allow-paths.feature
@@ -118,7 +118,7 @@ Feature: Paths may be explicitly allowed, otherwise restrictive default access c
       }
       """
 
-  Scenario: You may not access a file that belongs to a different folder outside of allowed paths with the same prefix.
+  Scenario: You may not access files in a sibling directory that shares the allowed path prefix.
     Given I provide input YAML:
       """
       dataset: !reference {path: ../example/data01.yaml}


### PR DESCRIPTION
Adds a regression test to `allow-paths.feature` that catches a subtle security issue caught by copilot in review of [`yaml-reference-ts`](https://github.com/dsillman2000/yaml-reference-ts/pull/6/changes/BASE..721df4f00a53fcb155daba7d780556a622237bac#r2831101054)

If `example` is an allowed path, a naive startsWith check would also permit references to files within `examplesecrets`, since `"examplesecrets".startsWith("example")` is `true`.
