### PR TITLE
fix: implement `main.go` to export a CLI as `yaml-reference-specs`.

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/cucumber/godog"
+	"github.com/cucumber/godog/colors"
+)
+
+func main() {
+	var cliExecutable string
+	if val, exists := os.LookupEnv("YAML_REFERENCE_CLI_EXECUTABLE"); exists {
+		cliExecutable = val
+	}
+
+	// Parse command line flags
+	format := flag.String("format", "pretty", "Format of output (pretty, junit, etc.)")
+	flag.Parse()
+
+	// Validate CLI executable
+	if cliExecutable == "" {
+		fmt.Fprintf(os.Stderr, "Error: YAML_REFERENCE_CLI_EXECUTABLE environment variable must be set\n")
+		os.Exit(1)
+	}
+
+	if _, err := os.Stat(cliExecutable); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: CLI executable not found at %s: %v\n", cliExecutable, err)
+		os.Exit(1)
+	}
+
+	// Configure godog options
+	var opts = godog.Options{
+		Output: colors.Colored(os.Stdout),
+		Format: *format,
+		Paths:  []string{"features"},
+	}
+
+	// Run the test suite
+	status := godog.TestSuite{
+		Name:                "yaml-reference CLI Test Suite",
+		ScenarioInitializer: InitializeScenario,
+		Options:             &opts,
+	}.Run()
+
+	os.Exit(status)
+}


### PR DESCRIPTION
## Overview
Adds a `main.go` entrypoint that exports the yaml-reference-specs test suite as a standalone CLI binary, enabling downstream projects to validate their implementations.

## Changes
- **Added:** `main.go` — CLI binary that runs the godog feature tests against any yaml-reference CLI implementation

## Key Features
- **Environment Variable:** Accepts `YAML_REFERENCE_CLI_EXECUTABLE` to point to the CLI being tested
- **Validation:** Checks that the executable exists before running tests
- **Formatting:** Supports `--format` flag (pretty, junit, etc.) for CI/CD integration
- **Portable:** Installable via `go install github.com/dsillman2000/yaml-reference-specs@latest`

## Usage
Downstream projects can now validate their CLI implementations:
```bash
go install github.com/dsillman2000/yaml-reference-specs@latest
YAML_REFERENCE_CLI_EXECUTABLE=/path/to/their/cli yaml-reference-specs --format junit
```

## Benefits
✅ External projects can test their implementations against the specs  
✅ CI/CD integration via environment variables  
✅ No code duplication with existing test suite  
✅ Simple to install and run
